### PR TITLE
Changed update observers to install observers with item.

### DIFF
--- a/LDSContent/ContentController.swift
+++ b/LDSContent/ContentController.swift
@@ -32,7 +32,7 @@ public class ContentController {
     let session = Session()
     
     public let catalogUpdateObservers = ObserverSet<Catalog>()
-    public let itemPackageUpdateObservers = ObserverSet<ItemPackage>()
+    public let itemPackageInstallObservers = ObserverSet<Item>()
     public let itemPackageUninstallObservers = ObserverSet<Item>()
     
     public static var sharedController: ContentController?
@@ -155,7 +155,7 @@ public class ContentController {
                         
                         try self.contentInventory.setSchemaVersion(Catalog.SchemaVersion, itemPackageVersion: item.version, forItemWithID: item.id)
                         
-                        self.itemPackageUpdateObservers.notify(itemPackage)
+                        self.itemPackageInstallObservers.notify(item)
                         
                         completion(.Success(itemPackage: itemPackage))
                     } catch let error as NSError {


### PR DESCRIPTION
Sending the item is more useful in the general sense because sometimes you want the item and it's hard to get the item from the package, but it's easy to get a package from the item.